### PR TITLE
🐛 Fix : 2번 단계, 도커 파일 기반 빌드에는 .env 파일이 없는 문제로 인한 삭제

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM openjdk:17-jdk
 # 작업 디렉토리 설정
 WORKDIR /app
 
-# `.env` 파일을 컨테이너 내부로 복사
-COPY .env .env
-
 # 애플리케이션 JAR 파일 복사
 COPY ./build/libs/*.jar app.jar
 


### PR DESCRIPTION
1. Jenkins 빌드 시작
2. Dockerfile 기반 프로젝트 Build & Image
3. Docker Image 실행 -> 도커 이미지 Run 이후에 .env 파일이 생기게 된다.
-> 도커 이미지 Run 이후에 .env 파일이 생기게 된다.