### PR TITLE
🐛  Fix: 회원가입 중복 사용자 계정 관리에 대한 수정 및 주문 관리 수정

### DIFF
--- a/src/main/java/com/example/codingmall/Order/OrderHistoryResponse.java
+++ b/src/main/java/com/example/codingmall/Order/OrderHistoryResponse.java
@@ -13,5 +13,6 @@ import java.util.List;
 public class OrderHistoryResponse {
     private Long orderId;
     private LocalDateTime orderDate;
+    private int orderAmount;
     private List<OrderItemResponse> orderItemList;
 }

--- a/src/main/java/com/example/codingmall/Order/OrderService.java
+++ b/src/main/java/com/example/codingmall/Order/OrderService.java
@@ -65,9 +65,10 @@ public class OrderService {
                 }
             }
         }
-
-        // Order 객체를 생성 (totalAmount는 createOrder에서 자동으로 계산됨)
-        Order order = Order.createOrder(user, orderRequest, orderItems, totalAmount);
+        int delivery_Fee = 3000;
+        int total = totalAmount + delivery_Fee; //배송비 추가
+        
+        Order order = Order.createOrder(user, orderRequest, orderItems, total);
 
         // Order의 OrderItem을 연결
         for (OrderItem orderItem : orderItems) {
@@ -176,6 +177,7 @@ public class OrderService {
                 .map(order -> OrderHistoryResponse.builder()
                         .orderId(order.getId())
                         .orderDate(order.getOrderDate())
+                        .orderAmount(order.getTotalAmount())
                         .orderItemList(order.getOrderItems().stream()
                                 .map(orderItem -> OrderItemResponse.builder()
                                         .itemId(orderItem.getItem().getId())

--- a/src/main/java/com/example/codingmall/User/Login/AuthService.java
+++ b/src/main/java/com/example/codingmall/User/Login/AuthService.java
@@ -48,6 +48,11 @@ public class AuthService {
                         .statusCode(200)
                         .build();
             }
+        } catch (UsernameAlreadyExistsException e) {
+            return JwtResponse.builder()
+                    .statusCode(400)
+                    .error(e.getMessage())
+                    .build();
         } catch (Exception e) {
             return JwtResponse.builder()
                     .statusCode(500)


### PR DESCRIPTION
1. 회원가입 시에 중복된 사용자 계정으로 다시 회원가입을 해도 되는 문제를 해결하였습니다.
2. 주문 시 배달료를 자동으로 3000원 추가하도록 수정하였습니다.
3. 주문 시 주문 테이블에는 주문 가격이 제대로 측정되어 나오지만, 내 주문 목록 보기 페이지에서는 order_item의 총 가격이 재계산되어 나와, 실제 주문 가격이 나오지 않았기에 주문 가격이라는 변수를 추가하였습니다.