### PR TITLE
소셜 로그인을 Local에서 서버 주소로 변경, 생년월일과 전화번호에 관련한 기능을 주석으로 생성

### DIFF
--- a/src/main/java/com/example/codingmall/User/Login/OAuth2/CustomSuccessHandler.java
+++ b/src/main/java/com/example/codingmall/User/Login/OAuth2/CustomSuccessHandler.java
@@ -19,10 +19,12 @@ import java.util.HashMap;
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JWTUtils jwtUtils;
-    //http://localhost:8080/oauth2/authorization/google
-    //http://localhost:8080/oauth2/authorization/naver
-    /*@Value("${spring.frontend.url}")
-    private String frontendUrl;*/
+    //LOCAL
+    //http://localhost:8081/oauth2/authorization/google
+    //http://localhost:8081/oauth2/authorization/naver
+    //AWS
+    //https://leon.p-e.kr/oauth2/authorization/google
+    //https://leon.p-e.kr/oauth2/authorization/naver
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -45,9 +47,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);  // 7일 동안 유효
         response.addCookie(refreshTokenCookie);
 
+/*
         // 사용자에게 응답
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().write("로그인 성공"); //브라우저는 한 번에 하나의 응답만 처리할 수 있기 때문
-        //response.sendRedirect(frontendUrl);
+*/
+        // 로그인 성공 후 리디렉션할 URL
+        response.sendRedirect("https://leon.p-e.kr/successSocialLogin"); // 원하는 페이지로 이동
     }
 }

--- a/src/main/java/com/example/codingmall/User/Login/OAuth2dto/GoogleResponse.java
+++ b/src/main/java/com/example/codingmall/User/Login/OAuth2dto/GoogleResponse.java
@@ -1,9 +1,15 @@
 package com.example.codingmall.User.Login.OAuth2dto;
 
+import lombok.Getter;
+
+import java.time.LocalDate;
 import java.util.Map;
 
+@Getter
 public class GoogleResponse implements OAuth2Response {
     private final Map<String, Object> attribute;
+    private LocalDate birth;           //생년월일 (People API)
+    private String phoneNumber;     //전화번호 (People API)
 
     public GoogleResponse(Map<String, Object> attribute) {
         this.attribute = attribute;
@@ -32,5 +38,24 @@ public class GoogleResponse implements OAuth2Response {
     @Override
     public String getProfileImage() {
         return null;
+    }
+
+    //People API
+    public void setBirth(LocalDate birth) {
+        this.birth = birth;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    @Override
+    public String getPhoneNumber() {
+        return this.phoneNumber != null ? this.phoneNumber : null;
+    }
+
+    @Override
+    public String getBirth() {
+        return this.birth != null ? this.birth.toString() : null;
     }
 }

--- a/src/main/java/com/example/codingmall/User/Login/OAuth2dto/NaverResponse.java
+++ b/src/main/java/com/example/codingmall/User/Login/OAuth2dto/NaverResponse.java
@@ -1,10 +1,12 @@
 package com.example.codingmall.User.Login.OAuth2dto;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 public class NaverResponse implements OAuth2Response{
     private final Map<String, Object> attribute;
-
+    private LocalDate birth;           //생년월일
+    private String phoneNumber;     //전화번호
     public NaverResponse(Map<String, Object> attribute) {
         this.attribute = (Map<String, Object>) attribute.get("response");
     }
@@ -34,4 +36,13 @@ public class NaverResponse implements OAuth2Response{
         return null;
     }
 
+    //People API
+    @Override
+    public String getBirth() {
+        return this.birth != null ? this.birth.toString() : null;
+    }
+    @Override
+    public String getPhoneNumber() {
+        return this.phoneNumber != null ? this.phoneNumber : null;
+    }
 }

--- a/src/main/java/com/example/codingmall/User/Login/OAuth2dto/OAuth2Response.java
+++ b/src/main/java/com/example/codingmall/User/Login/OAuth2dto/OAuth2Response.java
@@ -15,4 +15,8 @@ public interface OAuth2Response {
 
     // 프로필 이미지
     String getProfileImage();
+
+    //People API
+    String getBirth();
+    String getPhoneNumber();
 }

--- a/src/main/java/com/example/codingmall/User/User.java
+++ b/src/main/java/com/example/codingmall/User/User.java
@@ -25,8 +25,8 @@ public class User implements UserDetails, OAuth2User {
 
     private String username; // 아이디
     private String password; // 비밀번호
-    @Column(nullable = false,name = "birth",columnDefinition = "DATE")
-    private LocalDate birth;       //  생년월일
+    @Column(name = "birth", nullable = true)
+    private LocalDate birth; //  생년월일
     @Column(nullable = false)
     private String name;     // 사용자 이름
     private String email;    // 이메일

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,18 +36,20 @@ spring:
             clientName: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirectUri: http://localhost:8080/login/oauth2/code/google
+            #redirectUri: http://localhost:8081/login/oauth2/code/google
+            redirectUri: https://leoan.p-e.kr/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope:
               - email
               - profile
-              - https://www.googleapis.com/auth/user.birthday.read
-              - https://www.googleapis.com/auth/user.phonenumbers.read
+              #- https://www.googleapis.com/auth/user.birthday.read
+              #- https://www.googleapis.com/auth/user.phonenumbers.read
           naver:
             clientName: naver
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirectUri: http://localhost:8080/login/oauth2/code/naver
+            #redirectUri: http://localhost:8081/login/oauth2/code/naver
+            redirectUri: https://leoan.p-e.kr/login/oauth2/code/naver
             authorizationGrantType: authorization_code
             scope:
               - email


### PR DESCRIPTION
## 📝 설명

소셜 로그인의 주소가 기존 Local -> AWS 서버 주소로 변경했습니다.
생년월일과 전화번호를 가져오는데 어려움이 있어 null 처리를 기본으로 하되, 가져올 수 있도록 하는 기능은 주석으로 구현했습니다.

## ✅ PR 유형

- [ ]  기존 사항 수정

## 💻 작업 내용

- 소셜 로그인 주소 변경, Scope 조정관련 기능 주석으로 구현

## 💬 PR 포인트

- 수정 사항 체크 부탁드립니다.