### PR TITLE
Order 리턴 타입 수정과 Plant 관련 수정

### DIFF
--- a/src/main/java/com/example/codingmall/Order/OrderController.java
+++ b/src/main/java/com/example/codingmall/Order/OrderController.java
@@ -20,9 +20,8 @@ public class OrderController {
 
     @PostMapping("/user/order/create")
     @Operation(summary = "주문 생성")
-    public ResponseEntity<String> create(@AuthenticationPrincipal User user, @RequestBody OrderRequest orderRequest, @RequestParam(value = "couponPublishId", required = false) Long couponPublishId){
-        orderService.createOrder(user, orderRequest, couponPublishId);
-        return ResponseEntity.ok("주문이 생성되었습니다.");
+    public ResponseEntity<Long> create(@AuthenticationPrincipal User user, @RequestBody OrderRequest orderRequest, @RequestParam(value = "couponPublishId", required = false) Long couponPublishId){
+        return ResponseEntity.ok(orderService.createOrder(user, orderRequest, couponPublishId));
     }
 
     @PostMapping("/user/order/create/fromCart")

--- a/src/main/java/com/example/codingmall/Plant/PlantController.java
+++ b/src/main/java/com/example/codingmall/Plant/PlantController.java
@@ -29,10 +29,24 @@ public class PlantController {
         return ResponseEntity.ok(allPlants);
     }
 
-    @PutMapping("Plant/update/{PlantId}")
-    @Operation(summary = "식물등록 수정하기", description = "등록한 식물을 수정합니다")
-    public ResponseEntity<PlantDto> updatePlang(@AuthenticationPrincipal User user , @RequestBody PlantDto plantDto){
-        PlantDto updatePlant = PlantDto.from(plantService.updatePlant(plantDto,user));
+    @PutMapping(value = "Plant/update/{PlantId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "식물 등록 수정하기 (이미지 포함)", description = "등록한 식물을 수정합니다")
+    public ResponseEntity<PlantDto> updatePlant(
+            @AuthenticationPrincipal User user ,
+            @PathVariable(value = "plantId") Long plantId,
+            @ModelAttribute(value = "request") PlantRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) throws  IOException {
+        PlantDto dto = PlantDto.builder()
+                .id(plantId)
+                .name(request.getName())
+                .idealTemperature(request.getIdealTemperature())
+                .idealHumidity(request.getIdealHumidity())
+                .idealSolidMoisture(request.getIdealSolidMoisture())
+                .idealLightIntensity(request.getIdealLightIntensity())
+                .growthTarget(request.getGrowthTarget())
+                .build();
+        PlantDto updatePlant = PlantDto.from(plantService.updatePlant(dto, user, image));
         return ResponseEntity.ok(updatePlant);
     }
 
@@ -40,8 +54,8 @@ public class PlantController {
     @Operation(summary = "식물 등록하기 (이미지 포함)", description = "식물 정보를 이미지와 함께 등록합니다.")
     public ResponseEntity<PlantDto> createPlant(
             @AuthenticationPrincipal User user,
-            @ModelAttribute PlantRequest request,
-            @RequestPart("image") MultipartFile image
+            @ModelAttribute(value = "request") PlantRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image
     ) throws IOException {
         PlantDto dto = PlantDto.builder()
                 .name(request.getName())


### PR DESCRIPTION
## 📝 설명

Order에서 Long -> String 으로 바꿨었던 주문 생성 부분을 다시 Long으로 되돌렸습니다. (프론트 요청)
Plant에서 식물 수정 부분에 이미지를 첨부하여 수정 가능하도록 만들었습니다.
Plant에서 식물의 이미지를 꼭 받지 않아도 되도록 수정했습니다. (기본 Null)

## ✅ PR 유형

- [x]  기존 코드 수정

## 💻 작업 내용

- Order의 주문 생성 수정, Plant 이미지 저장에 null 가능

## 💬 PR 포인트

- 수정 내용 확인 부탁드립니다.