### PR TITLE
식물에 삭제 기능 추가, 스웨거 주석 추가, 사용자 키트 구매 내역 없을 시 역할 변경 불가 예외 추가

### DIFF
--- a/src/main/java/com/example/codingmall/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/codingmall/Exception/GlobalExceptionHandler.java
@@ -24,4 +24,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), "ALREADY_PLANT_ROLE"));
     }
+
+    @ExceptionHandler(UserHasNotAnyOrderException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyHasRole(UserHasNotAnyOrderException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), "USER_HAS_NOT_ANY_ORDER"));
+    }
 }

--- a/src/main/java/com/example/codingmall/Exception/UserHasNotAnyOrderException.java
+++ b/src/main/java/com/example/codingmall/Exception/UserHasNotAnyOrderException.java
@@ -1,0 +1,7 @@
+package com.example.codingmall.Exception;
+
+public class UserHasNotAnyOrderException extends RuntimeException {
+    public UserHasNotAnyOrderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/codingmall/Order/OrderRepository.java
+++ b/src/main/java/com/example/codingmall/Order/OrderRepository.java
@@ -11,4 +11,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         return findById(orderId).orElseThrow(() -> new OrderIdNotFoundException("존재하지 않는 주문 ID 입니다 : " + orderId));
     }
     List<Order> findByUser(User user);
+
+    boolean existsByUser(User user);
 }

--- a/src/main/java/com/example/codingmall/Plant/PlantController.java
+++ b/src/main/java/com/example/codingmall/Plant/PlantController.java
@@ -70,6 +70,7 @@ public class PlantController {
     }
 
     @DeleteMapping("/plant/delete/{plantId}")
+    @Operation(summary = "식물 삭제하기", description = "식물을 이미지와 함께 삭제합니다")
     public ResponseEntity<Void> deleteItem(@PathVariable(name = "plantId") Long plantId){
         plantService.deletePlantById(plantId);
         return ResponseEntity.noContent().build(); // 삭제 후 응답없음.

--- a/src/main/java/com/example/codingmall/Plant/PlantService.java
+++ b/src/main/java/com/example/codingmall/Plant/PlantService.java
@@ -64,6 +64,9 @@ public class PlantService {
 
     @Transactional
     public void deletePlantById(Long plantId) {
+        Plant findPlant = plantRepository.findPlantByPlantId(plantId);
+        //기존 이미지 삭제
+        s3Service.deleteFile(findPlant.getImageUrl());
         plantRepository.deleteById(plantId);
     }
 }


### PR DESCRIPTION
## 📝 설명

1. 식물에 삭제 기능이 존재하지 않아 삭제 기능을 추가했습니다.
2. 삭제 기능에 주석 처리를 하지 않아, 주석 처리를 했습니다.
3. 사용자가 키트를 구매한 적이 없을 경우, Plant 역할로 수정되지 않도록 예외 처리를 추가했습니다.

## ✅ PR 유형

- [x]  새로운 기능 추가

## 💻 작업 내용

- Plant 삭제 기능 추가, 사용자 키트 구매 내역 없을 시 예외 처리 추가

## 💬 PR 포인트

- 기능 체크 부탁드립니다.