### PR TITLE
🐛 Fix: 식물 삭제하기 기능 수정, 식물 저장 방법 수정

### DIFF
--- a/src/main/java/com/example/codingmall/Plant/PlantService.java
+++ b/src/main/java/com/example/codingmall/Plant/PlantService.java
@@ -72,7 +72,10 @@ public class PlantService {
     public void deletePlantById(Long plantId) {
         Plant findPlant = plantRepository.findPlantByPlantId(plantId);
         //기존 이미지 삭제
-        s3Service.deleteFile(findPlant.getImageUrl());
+        String url = findPlant.getImageUrl();
+        if (url != null && url.trim().isEmpty()) {
+            s3Service.deleteFile(url);
+        }
         plantRepository.deleteById(plantId);
     }
 }

--- a/src/main/java/com/example/codingmall/PlantGrowthLog/PlantGrowthLogService.java
+++ b/src/main/java/com/example/codingmall/PlantGrowthLog/PlantGrowthLogService.java
@@ -33,8 +33,8 @@ public class PlantGrowthLogService {
                 .orElse(null);
         // 3. 일기가 없다면 새로 생성
         if (existLog == null) {
-            int totalGrowth = plantGrowthLogRequest.getGrowth() + plant.getTotalGrowth();   //입력된 성장 길이 + 기존 식물의 성장 길이
-            plant.updateGrowth(totalGrowth);                                                //식물의 성장 길이를 수정 (변경 감지로 수정)
+            int totalGrowth = plantGrowthLogRequest.getGrowth();   //입력된 성장 길이
+            plant.updateGrowth(totalGrowth);                       //식물의 성장 길이를 수정 (변경 감지로 수정)
             PlantGrowthLog growthLog = PlantGrowthLog.createLog(plant, plantGrowthLogRequest);
             plantGrowthLogRepository.save(growthLog);
             return growthLog.getId();


### PR DESCRIPTION
## 📝 설명

식물 삭제하기 기능에서 이미지가 Null인 경우 삭제가 되지 않는 버그를 수정했습니다.
식물 저장 방법이 기록 할 때마다 그 기록된 길이로 식물의 총 길이가 저장되도록 재수정했습니다.

## ✅ PR 유형

- [ ]  버그 수정

## 💻 작업 내용

- 식물 관련 버그 수정

## 💬 PR 포인트

- 수정 확인 부탁드립니다.